### PR TITLE
fix: match peerDependencies version to match advertised NestJS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "performance"
   ],
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+    "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
     "express": "^4.0.0",
     "fastify": "^4.0.0 || ^5.0.0"
   },


### PR DESCRIPTION
The documentation advertises support for NestJS vesrion 11.x but `peerDependencies` only allows for versions 8-10 without using a force flag. This PR adds NestJS version 11. I assume that this was just an oversight.

Fixes: #13